### PR TITLE
`Listing`

### DIFF
--- a/babisteps/basemodels/complextracking.py
+++ b/babisteps/basemodels/complextracking.py
@@ -1463,10 +1463,21 @@ class ComplexTracking(BaseGenerator):
 
         random.shuffle(options)
         json['options'] = options
-        if self.name:
-            json['leaf'] = self.name.split('_-_')[0]
-            json['leaf_label'] = self.name.split('_-_')[1]
-            json['leaf_index'] = self.name.split('_-_')[2]
+        if self.name and "_-_" in self.name:
+            parts = self.name.split("_-_")
+            if len(parts) == 3:
+                json["leaf"] = parts[0]
+                json["leaf_label"] = parts[1]
+                json["leaf_index"] = parts[2]
+            else:
+                raise ValueError(
+                    "self.name does not contain exactly three parts separated by '_-_'"
+                )
+        else:
+            raise ValueError(
+                "self.name is either None or does not contain the delimiter '_-_'"
+            )
+
         return json
 
     def get_txt(self):

--- a/babisteps/basemodels/groups.py
+++ b/babisteps/basemodels/groups.py
@@ -119,10 +119,6 @@ def _get_object_transaction_OR_result(n_locs: int, y_i_group: Group,
         return np.where(y_f_bin == 1)[0]
     if y_f_nowhere:
         return np.where(y_i_bin == 1)[0]
-    # # Any is NOWHERE -> peform AND
-    # if y_i_nowhere or y_f_nowhere:
-    #     _and = y_i_bin & y_f_bin
-    #     return np.where(_and == 1)[0]
 
     # Both NOT NOWHERE -> do OR
     _or = y_i_bin | y_f_bin
@@ -165,7 +161,6 @@ def _get_forward(
             d = deltas[i]
             tx = d[0]
             if tx == (1, 0):
-                # x_i = d[1][0]
                 x_f = d[2][0]
                 y_i = d[1][1]
                 # check if the actor is in a group

--- a/babisteps/basemodels/immediateorder.py
+++ b/babisteps/basemodels/immediateorder.py
@@ -451,10 +451,21 @@ class ImmediateOrder(BaseGenerator):
 
         random.shuffle(options)
         json["options"] = options
-        if self.name:
-            json["leaf"] = self.name.split("_-_")[0]
-            json["leaf_label"] = self.name.split("_-_")[1]
-            json["leaf_index"] = self.name.split("_-_")[2]
+        if self.name and "_-_" in self.name:
+            parts = self.name.split("_-_")
+            if len(parts) == 3:
+                json["leaf"] = parts[0]
+                json["leaf_label"] = parts[1]
+                json["leaf_index"] = parts[2]
+            else:
+                raise ValueError(
+                    "self.name does not contain exactly three parts separated by '_-_'"
+                )
+        else:
+            raise ValueError(
+                "self.name is either None or does not contain the delimiter '_-_'"
+            )
+
         return json
 
     def get_txt(self):

--- a/babisteps/basemodels/listing.py
+++ b/babisteps/basemodels/listing.py
@@ -1,0 +1,319 @@
+import random
+from typing import Any, Callable, Literal, Optional, Union, get_type_hints
+from itertools import combinations
+
+
+from pydantic import BaseModel, model_validator
+
+from babisteps.basemodels.nodes import (Coordenate, Entity)
+from babisteps.basemodels.generators import SimpleTrackerBaseGenerator
+
+# -------------------------
+# Answer
+# -------------------------
+
+
+class ListingRequest(BaseModel):
+    answer: Any
+    entities: Optional[list[Entity]] = None
+    coordenate: Optional[Coordenate] = None
+
+    def get_question(self):
+        pass
+
+    def get_answer(self):
+        pass
+
+class ActorInLocationWho(ListingRequest):
+    answer: Union[int, Literal["none", "unknown"]]
+
+    @model_validator(mode='after')
+    def validate_answer(self):
+        if isinstance(self.answer, int) and self.answer <= 1:
+            raise ValueError("If answer is an integer, it must be greater than 1")
+        return self
+
+    def get_question(self):
+        return f"Who is in the {self.coordenate.name}?"
+
+    def get_answer(self):
+        if isinstance(self.answer, int):
+            return sorted([e.name for e in self.entities])
+        elif self.answer == "none" or self.answer == "unknown":
+            return [self.answer]
+        else:
+            raise ValueError(
+                "Invalid answer, should be 'designated_entities', 'none' or 'unknown'"
+            )
+
+class ActorWithObjectWhat(ListingRequest):
+    answer: Union[int, Literal["none"]]
+
+    @model_validator(mode='after')
+    def validate_answer(self):
+        if isinstance(self.answer, int) and self.answer <= 1:
+            raise ValueError("If answer is an integer, it must be greater than 1")
+        return self
+
+    def get_question(self):
+        return f"What has {self.coordenate.name}?"
+
+    def get_answer(self):
+        if isinstance(self.answer, int):
+            return sorted([e.name for e in self.entities])
+        elif self.answer == "none" or self.answer == "unknown":
+            return [self.answer]
+        else:
+            raise ValueError(
+                "Invalid answer, should be 'designated_entities', 'none' or 'unknown'"
+            )
+        
+class Listing(SimpleTrackerBaseGenerator):
+    topic: ListingRequest
+
+
+    def load_ontology_from_topic(self) -> Callable:
+        # Define the mapping between answer types and loader functions
+        loader_mapping: dict[type[ListingRequest], Callable] = {
+            ActorInLocationWho: self._actor_in_location_who,
+            ActorWithObjectWhat: self._actor_with_object_what,
+        }
+        uncertainty_mapping: dict[type[ListingRequest], Coordenate] = {
+            ActorInLocationWho: Coordenate(name="nowhere"),
+            ActorWithObjectWhat: None,
+        }
+
+        # Get the type of the answer
+        topic_type = type(self.topic)
+
+        if topic_type not in loader_mapping:
+            raise ValueError(
+                f"Unsupported answer type: {topic_type.__name__}. "
+                f"Should be one of {[cls.__name__ for cls in loader_mapping]}"
+            )
+        # Set the uncertainty based on the answer type
+        if uncertainty_mapping[topic_type]:
+            self.uncertainty = uncertainty_mapping[topic_type]
+
+        return loader_mapping[topic_type]
+
+    def get_random_combinations(self, n):
+        """
+        Returns n random combinations (subsets) of the input list.
+        The empty set and the full set are included in the possible combinations.
+        Order doesn't matter.
+        
+        Args:
+            string_list: List of strings
+            n: Number of random combinations to return
+            
+        Returns:
+            List of n random combinations (as lists)
+        """
+        string_list = [e.name for e in self.model.entities]
+        # Calculate total possible combinations: 2^len(string_list)
+        total_possible = 2**len(string_list)
+        
+        # If n >= total possible combinations, generate all combinations
+        if n >= total_possible:
+            result = []  # Start with empty set
+            for r in range(1, len(string_list) + 1):
+                for comb in combinations(string_list, r):
+                    result.append(list(comb))
+            return result
+        
+        # Generate n random unique combinations
+        result = set()
+        
+        # Ensure we have n unique combinations
+        while len(result) < n:
+            # Choose a random size for this combination
+            size = random.randint(2, len(string_list))
+            comb = tuple(sorted(random.sample(string_list, size)))
+            result.add(comb)
+        
+        # Convert set of tuples back to list of lists
+        return [list(comb) for comb in result]
+
+    def _actor_in_location_who(self):
+        c = self.model.coordenates[0]
+        self.topic.coordenate = c
+        if isinstance(self.topic.answer, int):
+            e = self.model.entities[:self.topic.answer]
+            self.topic.entities = e
+        self.model.coordenates.append(self.uncertainty)
+        self._create_aux()
+        self.logger.info(
+            "Creating _actor_in_location_who",
+            answer=self.topic.answer,
+            e=([e.name for e in self.topic.entities] 
+               if self.topic.entities else self.topic.answer),
+            c=c.name,
+        )
+        states = [None] * self.states_qty
+
+        if isinstance(self.topic.answer, int):
+            q = self.topic.answer
+            i = self.states_qty - 1
+            condition = lambda x: sum(x[0,:q]) == q and sum(x[0, q:]) == 0
+            states[i] = self.initialize_state(i, condition)
+            for j in list(reversed(range(i))):
+                condition = lambda x: True
+                states[j] = self.create_new_state(j, states[j + 1], condition)
+
+        elif self.topic.answer == "none":
+            self.logger.debug("Creating _actor_in_location_who with answer none")
+            i = self.states_qty - 1
+            condition = lambda x: sum(x[0, :]) == 0 and sum(x[-1, :]) < self.states_qty
+            states[i] = self.initialize_state(i, condition)
+
+            EIU = states[i].get_entities_in_coodenate(self.c2idx[self.uncertainty])
+
+            if EIU:
+                self.logger.debug(
+                    "Entities in uncertainty",
+                    EIU=EIU,
+                )
+                while EIU:
+                    EIU = states[i].get_entities_in_coodenate(
+                        self.c2idx[self.uncertainty]
+                    )
+                    for j in list(reversed(range(i))):
+                        ue = random.choice(self.model.entities)
+                        x_ue = self.e2idx[ue]
+                        if x_ue in EIU:
+                            self.logger.debug(
+                                "Trying to place entity from NW to coordenate c",
+                                entity=x_ue,
+                                coordenate=self.c2idx[c],
+                                left=len(EIU) - 1,
+                            )
+                            condition = lambda x, x_ue=x_ue: x[0, x_ue] == 1
+                            EIU.remove(x_ue)
+                        else:
+                            condition = lambda x, EIU=EIU: all(
+                                x[-1, EIU].todense() == [1] * len(EIU)
+                            )
+                        states[j] = self.create_new_state(j, states[j + 1], condition)
+            else:
+                self.logger.debug("There were not entities in uncertainty")
+                for j in list(reversed(range(i))):
+                    condition = lambda x: True
+                    states[j] = self.create_new_state(j, states[j + 1], condition)
+
+        elif self.topic.answer == "unknown":
+            i = self.states_qty - 1
+            empty_l = lambda x: sum(x[0, :]) == 0
+            some_in_UN = lambda x: sum(x[-1, :]) > 0
+
+            condition = lambda x: empty_l(x) and some_in_UN(x)
+            states[i] = self.initialize_state(i, condition)
+            EIU = states[i].get_entities_in_coodenate(self.c2idx[self.uncertainty])
+            for j in list(reversed(range(i))):
+                ue = random.choice(self.model.entities)
+                x_ue = self.e2idx[ue]
+                if x_ue in EIU:
+                    condition = (
+                        lambda x, x_ue=x_ue: x[0, x_ue] == 0 and x[-1, x_ue] == 0
+                    )
+                    EIU.remove(x_ue)
+                else:
+                    condition = lambda x: all(x[-1, EIU].todense() == [1] * len(EIU))
+                states[j] = self.create_new_state(j, states[j + 1], condition)
+        else:
+            raise ValueError("Invalid answer value")
+        self.logger.info(
+            "actor_in_location_who successfully created:",
+            answer=self.topic.answer,
+            e=([e.name for e in self.topic.entities] 
+               if self.topic.entities else self.topic.answer),
+            c=c.name,
+        )
+        return states
+
+    def _actor_with_object_what(self):
+        c = self.model.coordenates[0]
+        self.topic.coordenate = c
+        if isinstance(self.topic.answer, int):
+            e = self.model.entities[:self.topic.answer]
+            self.topic.entities = e
+        self.model.coordenates.append(self.uncertainty)
+        self._create_aux()
+        self.logger.info(
+            "Creating _actor_with_object_what",
+            answer=self.topic.answer,
+            e=([e.name for e in self.topic.entities] 
+               if self.topic.entities else self.topic.answer),
+            c=c.name,
+        )
+        states = [None] * self.states_qty
+
+        i = self.states_qty - 1
+        if isinstance(self.topic.answer, int):
+            q = self.topic.answer
+            condition = lambda x: sum(x[0,:q]) == q and sum(x[0, q:]) == 0
+        elif self.topic.answer == "none":
+            condition = lambda x: sum(x[0, :]) == 0
+        else:
+            raise ValueError(
+                "Invalid answer value, should be 'designated_object' or 'none'"
+            )
+
+        states[i] = self.initialize_state(i, condition)
+        for j in list(reversed(range(i))):
+            condition = lambda x: True
+            states[j] = self.create_new_state(j, states[j + 1], condition)
+
+        self.logger.info(
+            "_actor_with_object_what successfully created:",
+            answer=self.topic.answer,
+            e=([e.name for e in self.topic.entities] 
+               if self.topic.entities else self.topic.answer),
+            c=c.name,
+        )
+        return states
+
+    def generate(self):
+        self.create_ontology()
+        self.create_fol()
+
+    def get_json(self):
+        json = self.story.create_json()
+        if isinstance(self.topic, ActorInLocationWho):
+            options = [["none"], ["unknown"]]
+        elif isinstance(self.topic, ActorWithObjectWhat):
+            options = [["none"]]
+        else:
+            raise ValueError("Invalid answer type")
+        o = self.get_random_combinations(n=6)
+        if isinstance(self.topic.answer, int):
+            if self.topic.entities is None:
+                raise ValueError("self.topic.entities is None, cannot derive 'anws'")
+            anws = sorted([e.name for e in self.topic.entities])
+            # if is not in the options, add it
+            if anws not in options:
+                options.append(anws)
+        options.extend(o)
+        # Shuffle to avoid bias in the answer order
+        random.shuffle(options)
+        json["options"] = options
+
+        if self.name and "_-_" in self.name:
+            parts = self.name.split("_-_")
+            if len(parts) == 3:
+                json["leaf"] = parts[0]
+                json["leaf_label"] = parts[1]
+                json["leaf_index"] = parts[2]
+            else:
+                raise ValueError(
+                    "self.name does not contain exactly three parts separated by '_-_'"
+                )
+        else:
+            raise ValueError(
+                "self.name is either None or does not contain the delimiter '_-_'"
+            )
+
+        return json
+
+    def get_txt(self):
+        return self.story.create_txt()    

--- a/babisteps/basemodels/simpletracking.py
+++ b/babisteps/basemodels/simpletracking.py
@@ -530,10 +530,20 @@ class SimpleTracker(SimpleTrackerBaseGenerator):
         random.shuffle(options)
         json["options"] = options
 
-        if self.name:
-            json["leaf"] = self.name.split("_-_")[0]
-            json["leaf_label"] = self.name.split("_-_")[1]
-            json["leaf_index"] = self.name.split("_-_")[2]
+        if self.name and "_-_" in self.name:
+            parts = self.name.split("_-_")
+            if len(parts) == 3:
+                json["leaf"] = parts[0]
+                json["leaf_label"] = parts[1]
+                json["leaf_index"] = parts[2]
+            else:
+                raise ValueError(
+                    "self.name does not contain exactly three parts separated by '_-_'"
+                )
+        else:
+            raise ValueError(
+                "self.name is either None or does not contain the delimiter '_-_'"
+            )
 
         return json
 

--- a/babisteps/datasets.py
+++ b/babisteps/datasets.py
@@ -7,6 +7,7 @@ TASKS2NAME = {
     "1": "simpletracking",
     "2": "immediateorder",
     "3": "complextracking",
+    "4": "listing"
 }
 
 NAME2TASK = {value: key for key, value in TASKS2NAME.items()}
@@ -34,9 +35,10 @@ ds = load_dataset('PnyxAI/babisteps', <task>')
 The available tasks are:
 | Task ID | Task Name | Split Name|
 |---------|-----------|----|
-| 0       | simpletracking| test |
-| 1       | immediateorder| test |
-| 2       | complextracking| test |
+| 1       | simpletracking| test |
+| 2       | immediateorder| test |
+| 3       | complextracking| test |
+| 4       | listing| test |
 
 ### PAPER NAME
 

--- a/babisteps/tasks/listing/README.md
+++ b/babisteps/tasks/listing/README.md
@@ -1,0 +1,6 @@
+* `task_name`: name of the taks
+* `entities`: # of objects in the story
+* `coordenates`: # of actors in the story
+* `listing_qty`: Max # of entities in coordenate.
+* `gen_kwargs`: Set of possible generation probabilities
+* `func`: name of the function returning an iterable of story generators (like utils.<itarable of generators>)

--- a/babisteps/tasks/listing/config.yaml
+++ b/babisteps/tasks/listing/config.yaml
@@ -1,0 +1,6 @@
+task_name: listing
+entities: 7
+coordenates: 3
+listing_qty: 3
+gen_kwargs:
+func: utils._get_generators

--- a/babisteps/tasks/listing/utils.py
+++ b/babisteps/tasks/listing/utils.py
@@ -1,0 +1,102 @@
+import logging
+import os
+from copy import deepcopy
+from pathlib import Path
+
+import numpy as np
+import yaml
+
+from babisteps.basemodels.nodes import Coordenate, Entity
+from babisteps.basemodels.listing import (ActorInLocationWho,
+                                                 ActorWithObjectWhat,
+                                                 Listing)
+from babisteps.basemodels.simpletracking import EntitiesInCoordenates
+from babisteps.proccesing import prepare_path
+from babisteps.utils import generate_framework
+
+yaml_path = Path(__file__).parent / "config.yaml"
+task_leaf_list = [
+    ActorInLocationWho,
+    ActorWithObjectWhat,
+]
+
+
+def _get_generators(**kwargs):
+    # Commons
+    num_samples = kwargs.get("num_samples_by_task")
+    total_locations = kwargs.get("locations")
+    total_actors = kwargs.get("actors")
+    total_objects = kwargs.get("objects")
+    output_path = kwargs.get("output_path")
+    states_qty = kwargs.get("states_qty")
+    verbosity = getattr(logging, f"{kwargs.get('verbosity')}")
+    # Task
+    with open(yaml_path) as stream:
+        try:
+            yaml_cfg = yaml.safe_load(stream)
+        except yaml.YAMLError as exc:
+            print(exc)
+    framework = generate_framework(num_samples, task_leaf_list)
+    folder_name = yaml_cfg["task_name"]
+    folder_path = prepare_path(output_path, folder_name)
+    log_file = os.path.join(folder_path, "logs.txt")
+    n_entities = yaml_cfg.get("entities")
+    n_coordenates = yaml_cfg.get("coordenates")
+    listing_qty = yaml_cfg.get("listing_qty")
+    if listing_qty > n_entities:
+        raise ValueError(
+            f"listing_qty ({listing_qty}) must be less than "
+            f"or equal to # entities = {n_entities}"
+        )
+
+    def generator_func():
+        for leaf, answer, count in framework:
+            for i in range(count):
+                if not isinstance(answer, str):
+                    # +1 to include the last element and avoid [)
+                    answer = np.random.randint(2, listing_qty+1) 
+                gen_kwargs = yaml_cfg["gen_kwargs"]
+                # Check if a case of Actorin Location, or Actor with Object
+                if leaf in [
+                        ActorInLocationWho,
+                ]:
+                    shape_str = ("locations", "actors")
+                    entities_g = np.random.choice(total_actors,
+                                                  size=n_entities,
+                                                  replace=False).tolist()
+                    coordenates_g = np.random.choice(total_locations,
+                                                     size=n_coordenates,
+                                                     replace=False).tolist()
+                elif leaf in [
+                        ActorWithObjectWhat,
+                ]:
+                    shape_str = ("actors", "objects")
+                    entities_g = np.random.choice(total_objects,
+                                                  size=n_entities,
+                                                  replace=False).tolist()
+                    coordenates_g = np.random.choice(total_actors,
+                                                     size=n_coordenates,
+                                                     replace=False).tolist()
+
+                entities = [Entity(name=entity) for entity in entities_g]
+                coordenates = [
+                    Coordenate(name=coordenate) for coordenate in coordenates_g
+                ]
+                model = EntitiesInCoordenates(entities=entities,
+                                              coordenates=coordenates)
+                runtime_name = leaf.__name__ + "_-_" + str(answer) + "_-_" + str(i)
+                topic = leaf(answer=answer)
+
+                generator = Listing(
+                    model=deepcopy(model)._shuffle(),
+                    states_qty=states_qty,
+                    topic=topic,
+                    verbosity=verbosity,
+                    shape_str=shape_str,
+                    log_file=log_file,
+                    name=runtime_name,
+                    **gen_kwargs if gen_kwargs is not None else {},
+                )
+                yield generator
+
+    return generator_func(), folder_path

--- a/examples/Listing.ipynb
+++ b/examples/Listing.ipynb
@@ -1,0 +1,235 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "import os\n",
+    "import random\n",
+    "import sys\n",
+    "from copy import deepcopy\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import networkx as nx\n",
+    "import numpy as np\n",
+    "import yaml\n",
+    "from matplotlib import pyplot as plt\n",
+    "from typing import Literal\n",
+    "\n",
+    "\n",
+    "from babisteps import proccesing as proc\n",
+    "from babisteps import utils as ut\n",
+    "from babisteps.basemodels.listing import (\n",
+    "    Listing,\n",
+    "    ActorInLocationWho,\n",
+    "    ActorWithObjectWhat,\n",
+    "    )\n",
+    "from typing import get_type_hints\n",
+    "from babisteps.basemodels.nodes import Entity, Relationship, Coordenate\n",
+    "from babisteps.basemodels.simpletracking import EntitiesInCoordenates\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# yaml_path\n",
+    "yaml_common_path = './../babisteps/tasks/commons.yaml'\n",
+    "# Load the yaml file in yaml_test variable\n",
+    "with open(yaml_common_path, 'r') as file:\n",
+    "    yaml_commons = yaml.safe_load(file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output_path = Path('/home/giskard/Documents/POKTscan/code/bAbI-steps/outputs')\n",
+    "# add output_path to yaml_commons \n",
+    "yaml_commons['output_path'] = output_path"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Listing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "relations_qty = 3\n",
+    "n_entities = 7\n",
+    "n_coordenates = 6\n",
+    "listing_qty = 4\n",
+    "answer = \"none\"\n",
+    "verbosity = \"INFO\"\n",
+    "gen_kwargs = {}\n",
+    "path = os.path.join(os.getcwd())\n",
+    "\n",
+    "num_samples = yaml_commons.get(\"num_samples_by_task\")\n",
+    "total_locations = yaml_commons.get(\"locations\")\n",
+    "total_actors = yaml_commons.get(\"actors\")\n",
+    "total_objects = yaml_commons.get(\"objects\")\n",
+    "states_qty = yaml_commons.get(\"states_qty\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "leaf = ActorWithObjectWhat"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if leaf in [\n",
+    "        ActorInLocationWho,\n",
+    "]:\n",
+    "    shape_str = (\"locations\", \"actors\")\n",
+    "    entities_g = np.random.choice(total_actors,\n",
+    "                                    size=n_entities,\n",
+    "                                    replace=False).tolist()\n",
+    "    coordenates_g = np.random.choice(total_locations,\n",
+    "                                        size=n_coordenates,\n",
+    "                                        replace=False).tolist()\n",
+    "elif leaf in [\n",
+    "        ActorWithObjectWhat,\n",
+    "]:\n",
+    "    shape_str = (\"actors\", \"objects\")\n",
+    "    entities_g = np.random.choice(total_objects,\n",
+    "                                    size=n_entities,\n",
+    "                                    replace=False).tolist()\n",
+    "    coordenates_g = np.random.choice(total_actors,\n",
+    "                                        size=n_coordenates,\n",
+    "                                        replace=False).tolist()\n",
+    "\n",
+    "entities = [Entity(name=entity) for entity in entities_g]\n",
+    "coordenates = [\n",
+    "    Coordenate(name=coordenate) for coordenate in coordenates_g\n",
+    "]\n",
+    "model = EntitiesInCoordenates(entities=entities,\n",
+    "                                coordenates=coordenates)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "topic = leaf(answer=answer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "generator = Listing(\n",
+    "                model=deepcopy(model)._shuffle(),\n",
+    "                states_qty=states_qty,\n",
+    "                topic=topic,\n",
+    "                verbosity=verbosity,\n",
+    "                shape_str=shape_str,\n",
+    "                log_file=os.path.join(path, \"logs.txt\"),\n",
+    "                **gen_kwargs if gen_kwargs is not None else {},\n",
+    "            )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "generator.generate()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "json = generator.get_json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "txt = generator.get_txt()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(txt)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "babisteps-jEjEzKkT-py3.12",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
* **[New]:** Generator for task `listing`. Note: Formally, `options` key would include the combinatory of `entities`, then it was decided to limit the number of `options` to 6. 
* **[Adjusted]:** Fix in `_get_task_leaf_combinations` where definitions like

	```python
	answer: Union[int, Literal["none", "unknown"]]`
	```
	could't not be translated into `(int,"none", "unknown")` due to the use of `Literal`.
