### PR TITLE
lm-eval templates & filters

### DIFF
--- a/babisteps/lm_eval/chat-cot/_default_template_yaml
+++ b/babisteps/lm_eval/chat-cot/_default_template_yaml
@@ -11,8 +11,8 @@ doc_to_target: answer
 generation_kwargs:
   until:
     - "\n\n\n\n"
-    - "World enumeration"
-    - "Story"
+    - "## World enumeration ##"
+    - "## Story ##"
 filter_list:
   - name: get_response
     filter:

--- a/babisteps/lm_eval/chat-cot/_default_template_yaml
+++ b/babisteps/lm_eval/chat-cot/_default_template_yaml
@@ -2,16 +2,29 @@ dataset_path: <PATH/TO/REPLACE>
 test_split: test
 fewshot_split: test
 fewshot_config:
-  sampler: first_n
+  sampler: default
   doc_to_text: !function utils.fewshot_to_text
   doc_to_target: answer
 output_type: generate_until
 doc_to_text: !function utils.doc_to_text
 doc_to_target: answer
+generation_kwargs:
+  until:
+    - "\n\n\n\n"
+    - "World enumeration"
+    - "Story"
 filter_list:
   - name: get_response
     filter:
-      - function: GetResponse
+      - function: "lowercase"
+      # Filter everything after the first break line, ignoring leading newlines
+      - function: "regex"
+        regex_pattern: "^[\n]*([^\n]*)" # Updated regex
+      # Remove leading white spaces
+      - function: remove_whitespace
+      # function to ignore right white spaces or line breaks
+      - function: "regex"
+        regex_pattern: "^(.*?)\\s*$"
       - function: take_first
 num_fewshot: 3
 metric_list:

--- a/babisteps/lm_eval/chat-cot/babisteps.yaml
+++ b/babisteps/lm_eval/chat-cot/babisteps.yaml
@@ -3,3 +3,7 @@ task:
 - babisteps-chat-cot-task_01-simpletracking
 - babisteps-chat-cot-task_02-immediateorder
 - babisteps-chat-cot-task_03-complextracking
+- babisteps-chat-cot-task_04-listing
+- babisteps-chat-cot-task_05-sizeorder
+- babisteps-chat-cot-task_06-spatialorder
+- babisteps-chat-cot-task_07-temporalorder

--- a/babisteps/lm_eval/chat-cot/babisteps_task_01-simpletracking.yaml
+++ b/babisteps/lm_eval/chat-cot/babisteps_task_01-simpletracking.yaml
@@ -1,5 +1,7 @@
 dataset_name: simpletracking
-description: 'The following are basic taks on the subject of: simpletracking.'
+description: 'The following are basic taks (with answers) on the ability: simpletracking.
+
+  Return the answer to the question, without any explanation.'
 include: _default_template_yaml
 task: babisteps-chat-cot-task_01-simpletracking
 task_alias: task 01 - simpletracking

--- a/babisteps/lm_eval/chat-cot/babisteps_task_03-complextracking.yaml
+++ b/babisteps/lm_eval/chat-cot/babisteps_task_03-complextracking.yaml
@@ -1,5 +1,7 @@
 dataset_name: complextracking
-description: 'The following are basic taks on the subject of: complextracking.'
+description: 'The following are basic taks (with answers) on the ability: complextracking.
+
+  Return the answer to the question, without any explanation.'
 include: _default_template_yaml
 task: babisteps-chat-cot-task_03-complextracking
 task_alias: task 03 - complextracking

--- a/babisteps/lm_eval/chat-cot/babisteps_task_04-listing.yaml
+++ b/babisteps/lm_eval/chat-cot/babisteps_task_04-listing.yaml
@@ -1,0 +1,28 @@
+dataset_name: listing
+description: 'The following are basic taks (with answers) on the ability: listing.
+
+  Return the answer to the question, without any explanation.'
+include: _default_template_yaml
+task: babisteps-chat-cot-task_04-listing
+task_alias: task 04 - listing
+fewshot_config:
+  sampler: default
+  doc_to_text: !function utils.fewshot_to_text
+  doc_to_target: "{{answer | join(', ')}}"
+process_results: !function utils.process_results_listing
+filter_list:
+  - name: get_response
+    filter:
+      - function: "lowercase"    
+      # Filter everything after the first break line, ignoring leading newlines
+      - function: "regex"
+        regex_pattern: "^[\n]*([^\n]*)" # Updated regex
+      # Remove leading white spaces
+      - function: remove_whitespace
+      # function to ignore right white spaces or line breaks
+      - function: "regex"
+        regex_pattern: "^(.*?)\\s*$"
+      - function: "replace_regex" # Use the new filter type      
+        regex_pattern: " and" # The literal string " and" to match
+        replacement_string: "" # Replace with an empty string (this is the default)
+      - function: take_first

--- a/babisteps/lm_eval/chat-cot/babisteps_task_05-sizeorder.yaml
+++ b/babisteps/lm_eval/chat-cot/babisteps_task_05-sizeorder.yaml
@@ -1,10 +1,10 @@
-dataset_name: immediateorder
-description: 'The following are basic taks (with answers) on the ability: immediateorder.
+dataset_name: sizeorder
+description: 'The following are basic taks (with answers) on the ability: sizeorder.
 
   Return the answer to the question, without any explanation.'
 include: _default_template_yaml
-task: babisteps-chat-cot-task_02-immediateorder
-task_alias: task 02 - immediateorder
+task: babisteps-chat-cot-task_05-sizeorder
+task_alias: task 05 - sizeorder
 fewshot_config:
   sampler: default
   doc_to_text: !function utils.fewshot_to_text

--- a/babisteps/lm_eval/chat-cot/babisteps_task_06-spatialorder.yaml
+++ b/babisteps/lm_eval/chat-cot/babisteps_task_06-spatialorder.yaml
@@ -1,10 +1,10 @@
-dataset_name: immediateorder
-description: 'The following are basic taks (with answers) on the ability: immediateorder.
+dataset_name: spatialorder
+description: 'The following are basic taks (with answers) on the ability: spatialorder.
 
   Return the answer to the question, without any explanation.'
 include: _default_template_yaml
-task: babisteps-chat-cot-task_02-immediateorder
-task_alias: task 02 - immediateorder
+task: babisteps-chat-cot-task_06-spatialorder
+task_alias: task 06 - spatialorder
 fewshot_config:
   sampler: default
   doc_to_text: !function utils.fewshot_to_text

--- a/babisteps/lm_eval/chat-cot/babisteps_task_07-temporalorder.yaml
+++ b/babisteps/lm_eval/chat-cot/babisteps_task_07-temporalorder.yaml
@@ -1,10 +1,10 @@
-dataset_name: immediateorder
-description: 'The following are basic taks (with answers) on the ability: immediateorder.
+dataset_name: temporalorder
+description: 'The following are basic taks (with answers) on the ability: temporalorder.
 
   Return the answer to the question, without any explanation.'
 include: _default_template_yaml
-task: babisteps-chat-cot-task_02-immediateorder
-task_alias: task 02 - immediateorder
+task: babisteps-chat-cot-task_07-temporalorder
+task_alias: task 07 - temporalorder
 fewshot_config:
   sampler: default
   doc_to_text: !function utils.fewshot_to_text

--- a/babisteps/lm_eval/chat-cot/utils.py
+++ b/babisteps/lm_eval/chat-cot/utils.py
@@ -65,10 +65,10 @@ class ReplaceFilter(Filter):
 # ### Base ###
 def base_format(example: dict, include_options: bool) -> str:
     prompt = ""
-    prompt += "World enumeration:\n"
+    prompt += "## World enumeration ##\n"
     world = example["world_enumerate"]
     prompt += world
-    prompt += "\n\nStory:\n"
+    prompt += "\n\n## Story ##\n"
     story = example["story"]
     prompt += story
     prompt += "\nQuestion: "

--- a/babisteps/lm_eval/chat-cot/utils.py
+++ b/babisteps/lm_eval/chat-cot/utils.py
@@ -5,54 +5,109 @@ from lm_eval.api.registry import register_filter
 from lm_eval.filters.extraction import Filter
 
 
-def format_example(example, including_answer: bool):
-    prompt = "\n\nWorld enumeration:\n"
+###########################################################
+## Filters
+###########################################################
+@register_filter("replace_regex")  # Register with the same name as before
+class ReplaceFilter(Filter):
+    """A filter that replaces text using regex substitution, refactored."""
+
+    def __init__(
+        self,
+        regex_pattern: str,
+        replacement_string:
+        str = "",  # Default is an empty string to remove matches
+        count: int = 0  # Number of replacements to perform (0 means all)
+    ) -> None:
+        """
+        Compiles `regex_pattern` and replaces matches with `replacement_string`.
+        `count` specifies the maximum number of replacements.
+        Defaults to replacing all occurrences with an empty string 
+        (i.e., removing them).
+        """
+        self.regex_pattern = regex_pattern
+        self.regex = re.compile(regex_pattern)
+        self.replacement_string = replacement_string
+        self.count = count
+
+    def apply(self, resps: list[list[str]],
+              docs: list[dict]) -> list[list[str]]:
+        # Here, we assume resps is a list of lists, where each inner list is
+        # a set of model responses for a particular input/target pair.
+        # We process each of these inner lists independently.
+
+        def filter_set(inst: list[str]) -> list[str]:
+            """
+            Applies the regex replacement to each response string in a 
+            single instance's list.
+            Args:
+                inst: A list of strings (responses for one input).
+            Returns:
+                A list of strings with replacements applied.
+            """
+            filtered_instance = []
+            for resp in inst:  # resp is an individual string from the inner list
+                # Use re.sub for replacement
+                # re.sub returns a string after replacement
+                processed_resp = self.regex.sub(self.replacement_string,
+                                                resp,
+                                                count=self.count)
+                # Append the processed string (not a list of characters)
+                filtered_instance.append(processed_resp)
+            # filter_set returns a list of strings for this instance
+            return filtered_instance
+
+        filtered_resps = list(map(lambda x: filter_set(x), resps))
+        # filtered_resps will be a list[list[str]]
+        return filtered_resps
+
+
+# ### Base ###
+def base_format(example: dict, include_options: bool) -> str:
+    prompt = ""
+    prompt += "World enumeration:\n"
     world = example["world_enumerate"]
     prompt += world
     prompt += "\n\nStory:\n"
     story = example["story"]
     prompt += story
-    prompt += "\nQuestion:\n"
+    prompt += "\nQuestion: "
     question = example["question"]
-    options = example["options"]
-    prompt += question + "\n"
-    prompt += "Options:\n"
-    for i, opt in enumerate(options):
-        prompt += ".{}\n".format(opt)
+    prompt += question
+    if include_options:
+        prompt += "Options:\n"
+        options = example["options"]
+        for i, opt in enumerate(options):
+            prompt += "{}\n".format(opt)
     return prompt
 
 
-doc_to_text = partial(format_example, including_answer=False)
-fewshot_to_text = partial(format_example, including_answer=True)
+def format_example(example, include_options: bool, including_answer: bool):
+    prompt = base_format(example, include_options)
+    return prompt
 
 
-@register_filter("GetResponse")
-class GetResponse(Filter):
-    """ """
+doc_to_text = partial(format_example,
+                      include_options=False,
+                      including_answer=False)
+fewshot_to_text = partial(format_example,
+                          include_options=False,
+                          including_answer=True)
 
-    def apply(self, resps, docs):
-        filtered_resps = []
+# ### Listing ###
 
-        for r, doc in zip(resps, docs):
-            filtered = []
-            for resp in r:
-                if "</think>" in resp:
-                    # Remove CoT content
-                    resp = resp.split("</think>")[-1]
-                else:
-                    # Filter everything after the first break line
-                    # regex_pattern: "^(.*?)(?=\\n|$)"
-                    match = re.search(r"^(.*?)(?=\n|$)", resp)
-                    if match:
-                        resp = match.group(1)
-                # Remove leading white spaces
-                resp = resp.lstrip()
-                # function to ignore right white spaces or line breaks
-                # regex_pattern: "^(.*?)\\s*$"
-                match_trailing = re.search(r"^(.*?)\s*$", resp)
-                if match_trailing:
-                    resp = match_trailing.group(1)
-                filtered.append(resp)
-            filtered_resps.append(filtered)
 
-        return filtered_resps
+def process_results_listing(doc, results):
+    result_dict = {}
+    # convert doc['answer'] into a set
+    answer_set = set(doc['answer'])
+    # sub spaces with empty string
+    results[0] = results[0].replace(" ", "")
+    # split results into a list by spliting by ", "
+    results_list = results[0].split(",")
+    # convert results_list into a set
+    results_set = set(results_list)
+    # if both sets are equal, then 1, else 0
+    exact_match = 1 if answer_set == results_set else 0
+    result_dict["exact_match"] = exact_match
+    return result_dict

--- a/babisteps/lm_eval/default/_default_template_yaml
+++ b/babisteps/lm_eval/default/_default_template_yaml
@@ -11,8 +11,8 @@ doc_to_target: answer
 generation_kwargs:
   until:
     - "\n\n\n\n"
-    - "World enumeration"
-    - "Story"
+    - "## World enumeration ##"
+    - "## Story ##"
 filter_list:
   - name: get_response
     filter:

--- a/babisteps/lm_eval/default/_default_template_yaml
+++ b/babisteps/lm_eval/default/_default_template_yaml
@@ -2,18 +2,24 @@ dataset_path: <PATH/TO/REPLACE>
 test_split: test
 fewshot_split: test
 fewshot_config:
-  sampler: first_n
+  sampler: default
   doc_to_text: !function utils.fewshot_to_text
   doc_to_target: ""
 output_type: generate_until
 doc_to_text: !function utils.doc_to_text
 doc_to_target: answer
+generation_kwargs:
+  until:
+    - "\n\n\n\n"
+    - "World enumeration"
+    - "Story"
 filter_list:
   - name: get_response
     filter:
-      # Filter everything after the first break line
+      - function: "lowercase"
+      # Filter everything after the first break line, ignoring leading newlines
       - function: "regex"
-        regex_pattern: "^(.*?)(?=\\n|$)"
+        regex_pattern: "^[\n]*([^\n]*)" # Updated regex
       # Remove leading white spaces
       - function: remove_whitespace
       # function to ignore right white spaces or line breaks

--- a/babisteps/lm_eval/default/babisteps.yaml
+++ b/babisteps/lm_eval/default/babisteps.yaml
@@ -3,3 +3,7 @@ task:
 - babisteps-task_01-simpletracking
 - babisteps-task_02-immediateorder
 - babisteps-task_03-complextracking
+- babisteps-task_04-listing
+- babisteps-task_05-sizeorder
+- babisteps-task_06-spatialorder
+- babisteps-task_07-temporalorder

--- a/babisteps/lm_eval/default/babisteps_task_01-simpletracking.yaml
+++ b/babisteps/lm_eval/default/babisteps_task_01-simpletracking.yaml
@@ -1,5 +1,5 @@
 dataset_name: simpletracking
-description: 'The following are basic taks on the subject of: simpletracking.'
+description: 'The following are basic taks (with answers) on the ability: simpletracking.'
 include: _default_template_yaml
 task: babisteps-task_01-simpletracking
 task_alias: task 01 - simpletracking

--- a/babisteps/lm_eval/default/babisteps_task_03-complextracking.yaml
+++ b/babisteps/lm_eval/default/babisteps_task_03-complextracking.yaml
@@ -1,5 +1,5 @@
 dataset_name: complextracking
-description: 'The following are basic taks on the subject of: complextracking.'
+description: 'The following are basic taks (with answers) on the ability: complextracking.'
 include: _default_template_yaml
 task: babisteps-task_03-complextracking
 task_alias: task 03 - complextracking

--- a/babisteps/lm_eval/default/babisteps_task_04-listing.yaml
+++ b/babisteps/lm_eval/default/babisteps_task_04-listing.yaml
@@ -1,0 +1,27 @@
+dataset_name: listing
+description: 'The following are basic taks (with answers) on the ability: listing.'
+include: _default_template_yaml
+task: babisteps-task_04-listing
+task_alias: task 04 - listing
+fewshot_config:
+  sampler: default
+  doc_to_text: !function utils.listing_fewshot_to_text
+  doc_to_target: ""
+doc_to_text: !function utils.listing_doc_to_text
+process_results: !function utils.process_results_listing
+filter_list:
+  - name: get_response
+    filter:
+      - function: "lowercase"    
+      # Filter everything after the first break line, ignoring leading newlines
+      - function: "regex"
+        regex_pattern: "^[\n]*([^\n]*)" # Updated regex
+      # Remove leading white spaces
+      - function: remove_whitespace
+      # function to ignore right white spaces or line breaks
+      - function: "regex"
+        regex_pattern: "^(.*?)\\s*$"
+      - function: "replace_regex" # Use the new filter type      
+        regex_pattern: " and" # The literal string " and" to match
+        replacement_string: "" # Replace with an empty string (this is the default)
+      - function: take_first

--- a/babisteps/lm_eval/default/babisteps_task_05-sizeorder.yaml
+++ b/babisteps/lm_eval/default/babisteps_task_05-sizeorder.yaml
@@ -1,8 +1,8 @@
-dataset_name: immediateorder
-description: 'The following are basic taks (with answers) on the ability: immediateorder.'
+dataset_name: sizeorder
+description: 'The following are basic taks (with answers) on the ability: sizeorder.'
 include: _default_template_yaml
-task: babisteps-task_02-immediateorder
-task_alias: task 02 - immediateorder
+task: babisteps-task_05-sizeorder
+task_alias: task 05 - sizeorder
 fewshot_config:
   sampler: default
   doc_to_text: !function utils.rnd_choice_fewshot_to_text

--- a/babisteps/lm_eval/default/babisteps_task_06-spatialorder.yaml
+++ b/babisteps/lm_eval/default/babisteps_task_06-spatialorder.yaml
@@ -1,8 +1,8 @@
-dataset_name: immediateorder
-description: 'The following are basic taks (with answers) on the ability: immediateorder.'
+dataset_name: spatialorder
+description: 'The following are basic taks (with answers) on the ability: spatialorder.'
 include: _default_template_yaml
-task: babisteps-task_02-immediateorder
-task_alias: task 02 - immediateorder
+task: babisteps-task_06-spatialorder
+task_alias: task 06 - spatialorder
 fewshot_config:
   sampler: default
   doc_to_text: !function utils.rnd_choice_fewshot_to_text

--- a/babisteps/lm_eval/default/babisteps_task_07-temporalorder.yaml
+++ b/babisteps/lm_eval/default/babisteps_task_07-temporalorder.yaml
@@ -1,8 +1,8 @@
-dataset_name: immediateorder
-description: 'The following are basic taks (with answers) on the ability: immediateorder.'
+dataset_name: temporalorder
+description: 'The following are basic taks (with answers) on the ability: temporalorder.'
 include: _default_template_yaml
-task: babisteps-task_02-immediateorder
-task_alias: task 02 - immediateorder
+task: babisteps-task_07-temporalorder
+task_alias: task 07 - temporalorder
 fewshot_config:
   sampler: default
   doc_to_text: !function utils.rnd_choice_fewshot_to_text

--- a/babisteps/lm_eval/default/utils.py
+++ b/babisteps/lm_eval/default/utils.py
@@ -1,31 +1,157 @@
+import random
 import re
 from functools import partial
-import random
 
 from lm_eval.api.registry import register_filter
 from lm_eval.filters.extraction import Filter
 
 
-def format_example(example, including_answer: bool):
-    prompt = "\n\nWorld enumeration:\n"
+###########################################################
+## Filters
+###########################################################
+@register_filter("replace_regex")  # Register with the same name as before
+class ReplaceFilter(Filter):
+    """A filter that replaces text using regex substitution, refactored."""
+
+    def __init__(
+        self,
+        regex_pattern: str,
+        replacement_string:
+        str = "",  # Default is an empty string to remove matches
+        count: int = 0  # Number of replacements to perform (0 means all)
+    ) -> None:
+        """
+        Compiles `regex_pattern` and replaces matches with `replacement_string`.
+        `count` specifies the maximum number of replacements.
+        Defaults to replacing all occurrences with an empty string 
+        (i.e., removing them).
+        """
+        self.regex_pattern = regex_pattern
+        self.regex = re.compile(regex_pattern)
+        self.replacement_string = replacement_string
+        self.count = count
+
+    def apply(self, resps: list[list[str]],
+              docs: list[dict]) -> list[list[str]]:
+        # Here, we assume resps is a list of lists, where each inner list is
+        # a set of model responses for a particular input/target pair.
+        # We process each of these inner lists independently.
+
+        def filter_set(inst: list[str]) -> list[str]:
+            """
+            Applies the regex replacement to each response string in a 
+            single instance's list.
+            Args:
+                inst: A list of strings (responses for one input).
+            Returns:
+                A list of strings with replacements applied.
+            """
+            filtered_instance = []
+            for resp in inst:  # resp is an individual string from the inner list
+                # Use re.sub for replacement
+                # re.sub returns a string after replacement
+                processed_resp = self.regex.sub(self.replacement_string,
+                                                resp,
+                                                count=self.count)
+                # Append the processed string (not a list of characters)
+                filtered_instance.append(processed_resp)
+            # filter_set returns a list of strings for this instance
+            return filtered_instance
+
+        filtered_resps = list(map(lambda x: filter_set(x), resps))
+        # filtered_resps will be a list[list[str]]
+        return filtered_resps
+
+
+###########################################################
+# FORMAT
+###########################################################
+
+
+# ### Base ###
+def base_format(example: dict, include_options: bool) -> str:
+    prompt = ""
+    prompt += "\n\nWorld enumeration:\n"
     world = example["world_enumerate"]
     prompt += world
     prompt += "\n\nStory:\n"
     story = example["story"]
     prompt += story
-    prompt += "\nQuestion:\n"
+    prompt += "\nQuestion: "
     question = example["question"]
     prompt += question + "\n"
-    prompt += "Options:\n"
-    options = example["options"]
-    for i, opt in enumerate(options):
-        prompt += "{}. {}\n".format(i, opt)
-    prompt += "\nAnswer:\n"
+    if include_options:
+        prompt += "Options:\n"
+        options = example["options"]
+        for i, opt in enumerate(options):
+            prompt += "{}\n".format(opt)
+    prompt += "Answer: "
+    return prompt
+
+
+def format_example(example, include_options: bool, including_answer: bool):
+    prompt = base_format(example, include_options)
     if including_answer:
         answer = example["answer"]
         prompt += answer
     return prompt
 
 
-doc_to_text = partial(format_example, including_answer=False)
-fewshot_to_text = partial(format_example, including_answer=True)
+doc_to_text = partial(format_example,
+                      include_options=False,
+                      including_answer=False)
+fewshot_to_text = partial(format_example,
+                          include_options=False,
+                          including_answer=True)
+
+
+# ### ImmediateOrder ###
+def rnd_choice_answer_format_example(example, include_options: bool,
+                                     including_answer: bool):
+    prompt = base_format(example, include_options)
+    if including_answer:
+        answer = random.choice(example["answer"])
+        prompt += answer
+    return prompt
+
+
+rnd_choice_doc_to_text = partial(rnd_choice_answer_format_example,
+                                 include_options=False,
+                                 including_answer=False)
+rnd_choice_fewshot_to_text = partial(rnd_choice_answer_format_example,
+                                     include_options=False,
+                                     including_answer=True)
+
+
+# ### Listing ###
+def listing_format_example(example, include_options: bool,
+                           including_answer: bool):
+    prompt = base_format(example, include_options)
+    if including_answer:
+        answer = ', '.join(example["answer"])
+        prompt += answer
+    return prompt
+
+
+listing_doc_to_text = partial(listing_format_example,
+                              include_options=False,
+                              including_answer=False)
+listing_fewshot_to_text = partial(listing_format_example,
+                                  include_options=False,
+                                  including_answer=True)
+
+
+def process_results_listing(doc, results):
+    result_dict = {}
+    # convert doc['answer'] into a set
+    answer_set = set(doc['answer'])
+    # sub spaces with empty string
+    results[0] = results[0].replace(" ", "")
+    # split results into a list by spliting by ", "
+    results_list = results[0].split(",")
+    # convert results_list into a set
+    results_set = set(results_list)
+    # if both sets are equal, then 1, else 0
+    exact_match = 1 if answer_set == results_set else 0
+    result_dict["exact_match"] = exact_match
+    return result_dict

--- a/babisteps/lm_eval/default/utils.py
+++ b/babisteps/lm_eval/default/utils.py
@@ -71,10 +71,10 @@ class ReplaceFilter(Filter):
 # ### Base ###
 def base_format(example: dict, include_options: bool) -> str:
     prompt = ""
-    prompt += "\n\nWorld enumeration:\n"
+    prompt += "\n\n## World enumeration ##\n"
     world = example["world_enumerate"]
     prompt += world
-    prompt += "\n\nStory:\n"
+    prompt += "\n\n## Story ##\n"
     story = example["story"]
     prompt += story
     prompt += "\nQuestion: "


### PR DESCRIPTION
### ImmediateOrder, Listing and Ordering
* **[Add]:** `_generate_config.py` writes specific yaml config lines (default/chat-cot and task dependent).
* **[Adjusted]:** `sampler` config for fewshot changed from `first_n` to `default`.
* **[Add]:** particular `until` words to mitigate allucination (`"\n\n\n\n"`,`"World enumeration"`,`"Story"`)
* **[Adjusted]:** Filters: added `lowercase`, remove initial breaklines (from `"^(.*?)(?=\\n|$)"` to ` "^[\n]*([^\n]*)"`) to avoid empty extractions.
Note:
Specifically for `listing` task, it's also substracted `" and"` string via a new filter class `ReplaceFilter`.

### Listing:

* **[Add]:** `process_results_listing` handles results by checking if `set(answer) == set(response)`. Previously, from the filtered response of the model, spaces were removed and a list was generated separating the string by commas.

Close #24 